### PR TITLE
use -1 as the index to fill empty tokens in the label

### DIFF
--- a/keras_ocr/recognition.py
+++ b/keras_ocr/recognition.py
@@ -371,7 +371,7 @@ class Recognizer:
                 len(sentence) <= max_string_length
                 for sentence in sentences), 'A sentence is longer than this model can predict.'
             label_length = np.array([len(sentence) for sentence in sentences])[:, np.newaxis]
-            labels = np.array([[self.alphabet.index(c) for c in sentence] + [self.blank_label_idx] *
+            labels = np.array([[self.alphabet.index(c) for c in sentence] + [-1] *
                                (max_string_length - len(sentence)) for sentence in sentences])
             input_length = np.ones((batch_size, 1)) * max_string_length
             if len(batch[0]) == 3:


### PR DESCRIPTION
use -1 as the index to fill empty tokens in the label(e.g when it's length is smaller than the max_length string) as did in the original OCR example, to make things more "clear", since the blank token is already used in the CRNN(i.e CTC) architecture to have a different meaning. Also, I don't know if this can hurt the training since the CTC loss implementation in TF will anyway drop values at the indexes in a labels  that are superior to the length of the label itself (i.e label_length)