### PR TITLE
use augmenter in `convert_image_generator_to_recognizer_input`

### DIFF
--- a/keras_ocr/data_generation.py
+++ b/keras_ocr/data_generation.py
@@ -239,6 +239,7 @@ def convert_image_generator_to_recognizer_input(image_generator,
                                                 max_string_length,
                                                 target_width,
                                                 target_height,
+                                                augmenter=None,
                                                 margin=0):
     """Convert an image generator created by get_image_generator
     to (image, sentence) tuples for training a recognizer.
@@ -248,6 +249,7 @@ def convert_image_generator_to_recognizer_input(image_generator,
         max_string_length: The maximum string length to allow
         target_width: The width to warp lines into
         target_height: The height to warp lines into
+        augmenter: An image augmenter to be applied to backgrounds
         margin: The margin to apply around a single line.
     """
     while True:

--- a/keras_ocr/data_generation.py
+++ b/keras_ocr/data_generation.py
@@ -264,6 +264,8 @@ def convert_image_generator_to_recognizer_input(image_generator,
                                  target_width=target_width,
                                  target_height=target_height,
                                  margin=margin)
+            if augmenter is not None:
+                crop = augmenter(images=[crop])[0]
             yield crop, sentence
 
 


### PR DESCRIPTION
hello @faustomorales it would be cool to pass an augmenter to the convert_image_generator_to_recognizer_input to add some noise in the generated crop, I know it's possible to pass an augmenter to the get_image_generator but that augmenter is applied before adding the text to the background, however most of the time we want to add the background after adding the text since real-life images are in that form.