### PR TITLE
Warpbox distorts rotated bounding boxes

### DIFF
--- a/keras_ocr/tools.py
+++ b/keras_ocr/tools.py
@@ -36,6 +36,22 @@ def read(filepath_or_buffer: typing.Union[str, io.BytesIO]):
     return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
 
+def get_rotated_width_height(box):
+    """
+    Returns the width and height of a rotated rectangle
+
+    Args:
+        box: A list of four points starting in the top left
+        corner and moving clockwise.
+    """
+    w = (spatial.distance.cdist(box[0][np.newaxis], box[1][np.newaxis], "euclidean") + spatial.distance.cdist(
+        box[2][np.newaxis], box[3][np.newaxis], "euclidean")) / 2
+    h = (spatial.distance.cdist(box[0][np.newaxis], box[3][np.newaxis], "euclidean") + spatial.distance.cdist(
+        box[1][np.newaxis], box[2][np.newaxis], "euclidean")) / 2
+
+    return w, h
+
+
 def warpBox(image,
             box,
             target_height=None,
@@ -59,7 +75,7 @@ def warpBox(image,
     if cval is None:
         cval = (0, 0, 0) if len(image.shape) == 3 else 0
     box, _ = get_rotated_box(box)
-    _, _, w, h = cv2.boundingRect(box)
+    w, h = get_rotated_width_height(box)
     assert (
         (target_width is None and target_height is None)
         or (target_width is not None and target_height is not None)), \


### PR DESCRIPTION
Because the width and height calculated in WarpBox are taken from cv2.boundingRect, the non-rotated bbox width and height are used, which distorts rotated labels. The proposed change calculates the rotated rectangle width and height and warps it accordingly.
The code assumes the points are ordered correctly, which should be guaranteed by get_rotated_box.

Example label:
![rot_rect](https://user-images.githubusercontent.com/18501521/77762649-220e5480-703a-11ea-8b0f-76f95fa923e8.png)
Output from original code (default target height & width):
![warpbox1](https://user-images.githubusercontent.com/18501521/77762737-44a06d80-703a-11ea-9848-3d80216dd069.png)
After changes:
![warpbox2](https://user-images.githubusercontent.com/18501521/77762754-4b2ee500-703a-11ea-852e-f7f16796d1b8.png)

