### PR TITLE
provide information on invalid character in recognition data generator

### DIFF
--- a/keras_ocr/recognition.py
+++ b/keras_ocr/recognition.py
@@ -369,8 +369,8 @@ class Recognizer:
             sentences = [sample[1].strip() for sample in batch]
             if lowercase:
                 sentences = [sentence.lower() for sentence in sentences]
-            assert all(c in self.alphabet
-                       for c in ''.join(sentences)), 'Found illegal characters in sentence.'
+            for c in ''.join(sentences):
+                assert c in self.alphabet, 'Found illegal character: {}'.format(c)
             assert all(sentences), 'Found a zero length sentence.'
             assert all(
                 len(sentence) <= max_string_length


### PR DESCRIPTION
# Problem 

Recognition data generator doesn't provide information when data contains characters which weren't part of given alphabet.

This fix makes it explicit.