### PR TITLE
Added explicit exception when reading

### DIFF
--- a/keras_ocr/tools.py
+++ b/keras_ocr/tools.py
@@ -33,6 +33,8 @@ def read(filepath_or_buffer: typing.Union[str, io.BytesIO]):
         assert os.path.isfile(filepath_or_buffer), \
             'Could not find image at path: ' + filepath_or_buffer
         image = cv2.imread(filepath_or_buffer)
+    else:
+        raise Exception("Wrong input file type: should be 'str' or 'io.BytesIO' ")
     return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
 


### PR DESCRIPTION
The error is not understood otherwise and user is forced to look inside code to find what is going on.
Instead this is the displayed error: "UnboundLocalError: local variable 'image' referenced before assignment" because none of the conditions in if-statements where true so 'image' variable wouldn't have been defined hence this error, which is misleading since the real error resides at the input that shouldn't make the 'read' operation fail: raise an Exception that clearly shows that.