### PR TITLE
Avoid Relative Imports

### DIFF
--- a/keras_ocr/pipeline.py
+++ b/keras_ocr/pipeline.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-few-public-methods
 import numpy as np
 
-from . import detection, recognition, tools
+from keras_ocr import detection, recognition, tools
 
 
 class Pipeline:


### PR DESCRIPTION
If a user has a "tools" named package in their system, then relative import will fail.