### PR TITLE
exclude_smallcaps not working on windows

### DIFF
--- a/keras_ocr/data_generation.py
+++ b/keras_ocr/data_generation.py
@@ -255,6 +255,7 @@ def get_fonts(
             encoding="utf8",
         ) as f:
             smallcaps_fonts = f.read().split("\n")
+            smallcaps_fonts = [ origpath.replace('/', os.path.sep) for origpath in smallcaps_fonts ]
             font_filepaths = [
                 filepath
                 for filepath in font_filepaths


### PR DESCRIPTION
Since the path was not converted by the get_fonts function, it was not excluded even if True was given to the exclude_smallcaps parameter.