### PR TITLE
Update Python Version Compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ version = "0.0.0"
 
 # See https://python-poetry.org/docs/versions/ for allowed version specification formats
 [tool.poetry.dependencies]
-python = ">=3.7.5,<3.10"
+python = ">=3.7.5"
 validators = "*"
 essential_generators = "*"
 tqdm = "*"


### PR DESCRIPTION
Update Python Version Compatibility

This pull request removes the limitation of Python version 3.10 and allows support for Python versions up to 3.5. This change extends compatibility and ensures a broader range of Python versions can be used with the project.

**Note:** Google Colab use of Python version 3.10, this pull request addresses the compatibility issue with the Keras-OCR library. Currently, there is no candidate for Keras-OCR with the necessary fix, as outlined in [link to the GitHub issue](https://github.com/faustomorales/keras-ocr/pull/224).