### PR TITLE
Resolved dense layer initialization in recognition.py.

### DIFF
--- a/keras_ocr/recognition.py
+++ b/keras_ocr/recognition.py
@@ -276,10 +276,8 @@ def build_model(
         locnet_y = keras.layers.Dense(64, activation="relu")(locnet_y)
         locnet_y = keras.layers.Dense(
             6,
-            weights=[
-                np.zeros((64, 6), dtype="float32"),
-                np.array([[1, 0, 0], [0, 1, 0]], dtype="float32").flatten(),
-            ],
+            kernel_initializer= keras.initializers.Zeros(),
+            bias_initializer= keras.initializers.Constant([1, 0, 0, 0, 1, 0]),
         )(locnet_y)
         localization_net = keras.models.Model(inputs=stn_input_layer, outputs=locnet_y)
         x = keras.layers.Lambda(_transform, output_shape=stn_input_output_shape)(


### PR DESCRIPTION
The error is due to the wrong arguments sent previously in line 277. 'weights' is not the correct parameter for keras.layers.Dense(). It must kernel_initializer and bias_initializer. Now its working perfect. 